### PR TITLE
pipeline ci para gestorClientes

### DIFF
--- a/.github/workflows/pipeline_ci.yml
+++ b/.github/workflows/pipeline_ci.yml
@@ -74,5 +74,22 @@ jobs:
   #     working-directory: ./bodega
   #     run: pipenv run pytest --cov=src --cov-fail-under=70
 
+  # test-gestorClientes:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Install pipenv for gestorClientes
+  #     working-directory: ./gestorClientes
+  #     run: pip install pipenv
+  #   - name: Install dependencies for gestorClientes
+  #     working-directory: ./gestorClientes
+  #     run: pipenv install
+  #   - name: Synchronize .lock file
+  #     working-directory: ./gestorClientes
+  #     run: pipenv sync
+  #   - name: Run unit tests for gestorClientes
+  #     working-directory: ./gestorClientes
+  #     run: pipenv run pytest --cov=src --cov-fail-under=70
+
   
     


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pipeline_ci.yml` file. The change adds a commented-out section for running unit tests for the `gestorClientes` project. 

* Added a new job configuration for `gestorClientes` that includes steps for checking out the repository, installing `pipenv`, installing dependencies, synchronizing the `.lock` file, and running unit tests.