### PR TITLE
set puerto definido micros

### DIFF
--- a/bodega/Dockerfile
+++ b/bodega/Dockerfile
@@ -14,5 +14,8 @@ RUN pip install --no-cache-dir pipenv && \
 # Copiar el resto de los archivos de tu aplicación
 COPY . /app
 
+# Exponer el puerto que utiliza tu aplicación (ajusta según sea necesario)
+EXPOSE 3006
+
 # Comando para ejecutar la aplicación
 CMD ["pipenv", "run", "python", "app.py", "production"]

--- a/bodega/app.py
+++ b/bodega/app.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
             print(db_url)
             
             config_app(db_url)
-            serve(app, host="0.0.0.0", port=APP_PORT, threads=2)
+            serve(app, host="0.0.0.0", port=3006, threads=2)
             print('bad command')
 
     except IndexError:

--- a/vendedores/Dockerfile
+++ b/vendedores/Dockerfile
@@ -14,5 +14,8 @@ RUN pip install --no-cache-dir pipenv && \
 # Copiar el resto de los archivos de tu aplicación
 COPY . /app
 
+# Exponer el puerto que utiliza tu aplicación (ajusta según sea necesario)
+EXPOSE 3005
+
 # Comando para ejecutar la aplicación
 CMD ["pipenv", "run", "python", "app.py", "production"]

--- a/vendedores/app.py
+++ b/vendedores/app.py
@@ -39,7 +39,6 @@ if __name__ == '__main__':
         else:
             load_dotenv(".env.production")
 
-            APP_PORT=int(os.environ.get("SELLER_PORT"))
             DB_USER = os.environ.get('DB_USER')
             DB_PASSWORD = os.environ.get('DB_PASSWORD')
             DB_HOST = os.environ.get('DB_HOST')
@@ -51,7 +50,7 @@ if __name__ == '__main__':
             print(db_url)
             
             config_app(db_url)
-            serve(app, host="0.0.0.0", port=APP_PORT, threads=2)
+            serve(app, host="0.0.0.0", port=3005, threads=2)
             # print('bad command')
 
     except IndexError:


### PR DESCRIPTION
This pull request includes changes to expose specific ports for two applications and adjust the port configuration in their respective codebases. The changes ensure that both applications are set to use the correct ports consistently.

### Dockerfile updates:

* [`bodega/Dockerfile`](diffhunk://#diff-c6c2b0d9ec06a343dda7c2d4eb6925512c8a468697aa78150d138837e7f5e4f6R17-R19): Added an `EXPOSE` instruction to expose port 3006.
* [`vendedores/Dockerfile`](diffhunk://#diff-78210fdc0be23eeeb2a1d53b367c9499535795c5660949ebd388ea28daadf178R17-R19): Added an `EXPOSE` instruction to expose port 3005.

### Application port configuration:

* [`bodega/app.py`](diffhunk://#diff-daf47549375229944c8fb5a157b55c756321fa69dbb757f5a3f1bb0e2b779554L53-R53): Updated the `serve` function to use port 3006 instead of `APP_PORT`.
* [`vendedores/app.py`](diffhunk://#diff-483fcf36c97b8baed4527bba002bc8354beb20a0a64d21a5f80c4a017172fff9L42): Removed the `APP_PORT` environment variable and updated the `serve` function to use port 3005. [[1]](diffhunk://#diff-483fcf36c97b8baed4527bba002bc8354beb20a0a64d21a5f80c4a017172fff9L42) [[2]](diffhunk://#diff-483fcf36c97b8baed4527bba002bc8354beb20a0a64d21a5f80c4a017172fff9L54-R53)