### PR TITLE
incluir vendedores y stock en bff

### DIFF
--- a/bffClientes/src/blueprints/routes.py
+++ b/bffClientes/src/blueprints/routes.py
@@ -6,6 +6,8 @@ blueprint = Blueprint('bffClientes', __name__)
 
 MS_GESTOR_CLIENTES_URL = rf"{getenv('MS_GESTOR_CLIENTES_URL')}"
 MS_PEDIDOS_URL = rf"{getenv('MS_PEDIDOS_URL')}"
+MS_GESTOR_VENDEDORES_URL = rf"{getenv('MS_GESTOR_VENDEDORES_URL')}"
+MS_GESTOR_STOCK_URL = rf"{getenv('MS_GESTOR_STOCK_URL')}"
 
 def handle_requests(host, path):
     url = f"{host}/{path}"
@@ -36,4 +38,14 @@ def proxy_ms_gestor_clientes(path=None):
 @blueprint.route("/api/gestorPedidos/<path:path>", methods=["GET", "POST"])
 def proxy_ms_pedidos(path=None):
     response = handle_requests(MS_PEDIDOS_URL, path)
+    return jsonify(response.json()), response.status_code
+
+@blueprint.route("/api/gestorVendedores/<path:path>", methods=["GET", "POST"])
+def proxy_ms_vendedores(path=None):
+    response = handle_requests(MS_GESTOR_VENDEDORES_URL, path)
+    return jsonify(response.json()), response.status_code
+
+@blueprint.route("/api/gestorStock/<path:path>", methods=["GET", "POST"])
+def proxy_ms_stock(path=None):
+    response = handle_requests(MS_GESTOR_STOCK_URL, path)
     return jsonify(response.json()), response.status_code


### PR DESCRIPTION
This pull request introduces new routes to the `bffClientes` service to handle requests to the `MS_GESTOR_VENDEDORES` and `MS_GESTOR_STOCK` microservices. The most important changes are the addition of environment variables for these new microservices and the creation of new route handlers to proxy requests to them.

New environment variables:

* [`bffClientes/src/blueprints/routes.py`](diffhunk://#diff-dc427cc3e8ac2f84a4697b4fdcaa77b61226e14e73f88df275ac0771bb7ea687R9-R10): Added `MS_GESTOR_VENDEDORES_URL` and `MS_GESTOR_STOCK_URL` to the environment variables.

New route handlers:

* [`bffClientes/src/blueprints/routes.py`](diffhunk://#diff-dc427cc3e8ac2f84a4697b4fdcaa77b61226e14e73f88df275ac0771bb7ea687R42-R51): Added `proxy_ms_vendedores` and `proxy_ms_stock` functions to handle requests to the new microservices and return the appropriate responses.