### PR TITLE
fix crear bodega y posiciones al crear bodega

### DIFF
--- a/bodega/src/commands/bodega/crear_bodega.py
+++ b/bodega/src/commands/bodega/crear_bodega.py
@@ -35,9 +35,10 @@ class CrearBodega(BaseCommand):
         else:
             return False
         
-    def crear_posiciones(self, nombre_bodega: str, id_bodega: str) -> list:
-
-        valores = [f"{letra}{numero}" for letra in string.ascii_uppercase for numero in range(1, 4)]
+    def valores_posiciones(self) -> list:
+        return [f"{letra}{numero}" for letra in string.ascii_uppercase for numero in range(1, 4)]
+        
+    def crear_posiciones(self, valores: list, nombre_bodega: str, id_bodega: str) -> list:
 
         data_posiciones = [
             {
@@ -72,21 +73,22 @@ class CrearBodega(BaseCommand):
                 "status_code": 409
             }
         
-        
-        
         id_bodega = self.crear_uuid()
 
-        posiciones = self.crear_posiciones(self.bodega_template['nombre'], id_bodega)
+        valores_posiciones = self.valores_posiciones()
 
         nueva_bodega = Bodega(
             id=id_bodega,
             nombre=self.bodega_template['nombre'],
-            posiciones=posiciones,
+            posiciones=valores_posiciones,
             direccion=self.bodega_template['direccion'],
             latitude=self.bodega_template['latitude'],
             longitude=self.bodega_template['longitude'],
         )
         db.session.add(nueva_bodega)
+        db.session.commit()
+
+        posiciones = self.crear_posiciones(valores_posiciones, self.bodega_template['nombre'], id_bodega)
 
         try:
             db.session.commit()


### PR DESCRIPTION
This pull request refactors the `crear_posiciones` method in `bodega/src/commands/bodega/crear_bodega.py` to improve code clarity and reusability. The changes separate the generation of position values into its own method and adjust the flow of the `execute` method accordingly.

### Refactoring of position generation:

* [`bodega/src/commands/bodega/crear_bodega.py`](diffhunk://#diff-5674c3744e7268404a228e56e25ce2d97f74399d47e920d36cc4a0b4dd69efd5L38-R41): Introduced a new method `valores_posiciones` to encapsulate the logic for generating position values, improving reusability and separation of concerns.

### Adjustments to `execute` method:

* [`bodega/src/commands/bodega/crear_bodega.py`](diffhunk://#diff-5674c3744e7268404a228e56e25ce2d97f74399d47e920d36cc4a0b4dd69efd5L75-R91): Updated the `execute` method to call `valores_posiciones` for position generation and adjusted the flow to commit the new `Bodega` instance before creating positions. This ensures data consistency and better aligns with the database transaction flow.